### PR TITLE
Actions: Pass Docker registry password via stdin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Login to docker
-      run: docker login docker.pkg.github.com -u github-actions -p ${{ secrets.GITHUB_TOKEN }}
+      run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u github-actions --password-stdin
 
     - name: Build Images & Run Queries
       run: cd courses/cpp/ctf-segv && ../../../scripts/test-course-actual.sh


### PR DESCRIPTION
Follow the recommended practice and keep the token out of shell history and logs.
(Actions will probably filter the logs, but good to be cautious.)