### PR TITLE
Upgrade codeql to version 2.2.4

### DIFF
--- a/codeql-learninglab-check/Dockerfile
+++ b/codeql-learninglab-check/Dockerfile
@@ -26,10 +26,10 @@ RUN apt-get install -y nodejs
 # USER codeql
 
 # Add CodeQL repo
-RUN git clone https://github.com/Semmle/ql.git /home/codeql/codeql-home/codeql-repo
+RUN git clone https://github.com/github/codeql.git /home/codeql/codeql-home/codeql-repo
 
 WORKDIR /home/codeql/codeql-home/codeql-repo/
-RUN git checkout ed97be459fed23c9f07a0e1895176bad7ba6c686
+RUN git checkout c8dc2ee611c571d11999e2eb50bacd2b6e559829
 
 # Add and build code action code
 COPY --chown=codeql:codeql package /home/codeql/package

--- a/codeql-learninglab-check/Dockerfile
+++ b/codeql-learninglab-check/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.04
+FROM ubuntu:20.04
 
 RUN apt-get update
 RUN apt-get install -y wget unzip

--- a/codeql-learninglab-check/Dockerfile
+++ b/codeql-learninglab-check/Dockerfile
@@ -11,7 +11,7 @@ RUN chown codeql:codeql ~codeql
 USER codeql
 WORKDIR /home/codeql
 RUN mkdir ~/codeql-home
-RUN wget --quiet https://github.com/github/codeql-cli-binaries/releases/download/v2.0.0/codeql.zip -O codeql-2.0.0.zip && unzip ~/codeql-2.0.0.zip -d /home/codeql/codeql-home/ && rm -f ~/codeql-2.0.0.zip && mv ~/codeql-home/codeql ~/codeql-home/codeql-cli
+RUN wget --quiet https://github.com/github/codeql-cli-binaries/releases/download/v2.2.4/codeql.zip -O codeql-2.2.4.zip && unzip ~/codeql-2.2.4.zip -d /home/codeql/codeql-home/ && rm -f ~/codeql-2.2.4.zip && mv ~/codeql-home/codeql ~/codeql-home/codeql-cli
 
 ENV PATH="/home/codeql/codeql-home/codeql-cli/:${PATH}"
 

--- a/codeql-learninglab-check/README.md
+++ b/codeql-learninglab-check/README.md
@@ -18,19 +18,19 @@ This docker image bundles a number of elements:
 * **Dependency:** Some debian packages, importantly including Node v12.
 * **Dependency:** The CodeQL CLI binaries from
   [`codeql-cli-binaries`](https://github.com/github/codeql-cli-binaries/releases)
-* **Dependency:** A checkout of the [`Semmle/ql`](https://github.com/Semmle/ql)
+* **Dependency:** A checkout of the [`GitHub/codeql`](https://github.com/github/codeql)
   repository, pinned to a specific version.
 * The core action JavaScript/TypeScript code from [`package/`](package),
   and all its NPM dependencies.
 
 ## Updating the CodeQL dependencies
 
-You will want to make sure that the versions of the CodeQL CLI and `Semmle/ql`
+You will want to make sure that the versions of the CodeQL CLI and `GitHub/codeql`
 are compatible.
 
 * **Updating the CodeQL CLI**: Modify the URL for the CLI in
   [`Dockerfile`](Dockerfile).
-* **Updating the `Semmle/ql` repo**: Update the `RUN git checkout <ref>` line in
+* **Updating the `GitHub/codeql` repo**: Update the `RUN git checkout <ref>` line in
   [`Dockerfile`](Dockerfile) to a git sha / reference that is compatible with
   the version of the CodeQL CLI that is in use.
 


### PR DESCRIPTION
This PR:
- downloads the latest (v2.2.4) CodeQL CLI binaries,
- switches to the current `HEAD` of the CodeQL repository hosted in the GitHub organization.