### PR TITLE
remove master

### DIFF
--- a/templates/learninglab/course/generate-config.js
+++ b/templates/learninglab/course/generate-config.js
@@ -300,7 +300,7 @@ STEPS.map((step, i) => {
         body: |
           Congratulations, looks like the query you introduced for step ${INTRO_ISSUES.length + i + 1} finds the correct results!
 
-          Merge this Pull Request (unless you're on master), and take a look at the [instructions for the next step](%actions.next_issue.data.html_url%) to continue.
+          Merge this Pull Request (unless you're on the default branch), and take a look at the [instructions for the next step](%actions.next_issue.data.html_url%) to continue.
 
       # Close current issue
       - type: closeIssue

--- a/templates/learninglab/course/responses/fail.md
+++ b/templates/learninglab/course/responses/fail.md
@@ -1,3 +1,3 @@
 Ooops! The query you submitted in {{commit}} didn't find the right results. Have a look at the [comment]({{commentUrl}}). 
 
-To submit a new iteration of your query, you just have to push a new commit to the same branch (`master` or the PR branch).
+To submit a new iteration of your query, you just have to push a new commit to the same branch (your default branch, or the PR branch).


### PR DESCRIPTION
This is just changing the terms in some places that are used at templates when creating a new CodeQL learning lab. 